### PR TITLE
feat (API REST): Verifica se CPF ja foi cadastrado

### DIFF
--- a/src/main/java/br/com/coderbank/portalcliente/controllers/ControllerExceptionHandler.java
+++ b/src/main/java/br/com/coderbank/portalcliente/controllers/ControllerExceptionHandler.java
@@ -1,0 +1,27 @@
+package br.com.coderbank.portalcliente.controllers;
+
+import br.com.coderbank.portalcliente.dtos.response.ErrorResponseDTO;
+import br.com.coderbank.portalcliente.exceptions.ClienteJaExistenteException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+//Permite criar um componente global de tratamento de erros que pode ser usado por todos os controller
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+    //    Filtro que intercepta todas as exceções do tipo ClienteJaExistenteException. Sempre que ocorrer uma
+//    exceção do tipo ClienteJaExistenteException, o retorno será redirecionado para esse método.
+
+    @ExceptionHandler({ClienteJaExistenteException.class})
+//    Pegue o objeto que eu estou retornando e coloque-o diretamente no corpo da resposta HTTP.
+    @ResponseBody
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponseDTO conflict(final Throwable exception) {
+        final var exceptionMessage = exception.getMessage();
+
+        return new ErrorResponseDTO(exceptionMessage, System.currentTimeMillis());
+    }
+}

--- a/src/main/java/br/com/coderbank/portalcliente/dtos/response/ErrorResponseDTO.java
+++ b/src/main/java/br/com/coderbank/portalcliente/dtos/response/ErrorResponseDTO.java
@@ -1,0 +1,4 @@
+package br.com.coderbank.portalcliente.dtos.response;
+
+public record ErrorResponseDTO(String message, long timeStamp) {
+}

--- a/src/main/java/br/com/coderbank/portalcliente/exceptions/ClienteJaExistenteException.java
+++ b/src/main/java/br/com/coderbank/portalcliente/exceptions/ClienteJaExistenteException.java
@@ -1,0 +1,8 @@
+package br.com.coderbank.portalcliente.exceptions;
+
+public class ClienteJaExistenteException extends RuntimeException {
+
+    public ClienteJaExistenteException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/coderbank/portalcliente/repositories/ClienteRepository.java
+++ b/src/main/java/br/com/coderbank/portalcliente/repositories/ClienteRepository.java
@@ -32,4 +32,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface ClienteRepository extends JpaRepository<Cliente, UUID> {
+
+//Query methods: para criar consultas sql automaticamente de maneira programática
+// iniciamos com o nome da operação que queremos realizar seguido pelo nome do atributo da entidade
+
+    boolean existsByCpf(String numeroCpf);
 }

--- a/src/main/java/br/com/coderbank/portalcliente/services/ClienteService.java
+++ b/src/main/java/br/com/coderbank/portalcliente/services/ClienteService.java
@@ -4,6 +4,7 @@ import br.com.coderbank.portalcliente.dtos.request.ClienteRequestDTO;
 import br.com.coderbank.portalcliente.dtos.response.ClienteResponseDTO;
 import br.com.coderbank.portalcliente.entities.Cliente;
 import br.com.coderbank.portalcliente.entities.enums.Status;
+import br.com.coderbank.portalcliente.exceptions.ClienteJaExistenteException;
 import br.com.coderbank.portalcliente.repositories.ClienteRepository;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,8 @@ public class ClienteService {
     private ClienteRepository clienteRepository;
 
     public ClienteResponseDTO salvar(final ClienteRequestDTO clienteRequestDTO) {
+
+        verificarCpfDuplicado(clienteRequestDTO);
 
         var clienteEntity = new Cliente();
 
@@ -32,5 +35,13 @@ public class ClienteService {
                 clienteEntity.getEditadoPeloUsuario(),
                 clienteEntity.getEditadoDataEHora()
                 );
+    }
+
+    private void verificarCpfDuplicado(final ClienteRequestDTO clienteRequestDTO) {
+        final var numeroCpf = clienteRequestDTO.cpf();
+
+        if (clienteRepository.existsByCpf(numeroCpf)) {
+            throw new ClienteJaExistenteException("Cliente com o cpf " +numeroCpf + " já existe.");
+        }
     }
 }


### PR DESCRIPTION
A aplicação estava lançando erros ao tentar cadastrar um cliente com o mesmo cpf, então foi criada uma validação para checar se o cliente que estava sendo cadastrado já estava na base de dados, se tiver lança uma exceção, se não tiver deixa registrar o cliente.